### PR TITLE
Fix conj in cljs

### DIFF
--- a/src/lazy_map/core.cljs
+++ b/src/lazy_map/core.cljs
@@ -51,7 +51,7 @@
 
   ICollection
   (-conj [_ o]
-    (-conj contents o))
+    (LazyMap. (-conj contents o)))
 
   IEquiv
   (-equiv [_ other]


### PR DESCRIPTION
`conj` should return a new lazy map with the new entry added.